### PR TITLE
SCMOD-5937: Added additional test for deleting non-existent batch

### DIFF
--- a/staging-service-acceptance-tests/src/test/java/com/github/cafdataprocessing/services/staging/StagingServiceIT.java
+++ b/staging-service-acceptance-tests/src/test/java/com/github/cafdataprocessing/services/staging/StagingServiceIT.java
@@ -125,6 +125,17 @@ public class StagingServiceIT {
         }
     }
 
+    @Test
+    public void deleteNonExistingBatchTest() throws Exception {
+        final String batchId = "delNonExistingTestBatch";
+        try {
+            stagingApi.deleteBatch(batchId);
+            fail("Expected ApiException");
+        } catch (ApiException ex) {
+            assertEquals(404, ex.getCode());
+        }
+    }
+
     private StagingBatchResponse stageMultiParts(final String[] contentFiles, final String[] documentFiles)
             throws IOException, ApiException {
         final List<MultiPart> uploadData = new ArrayList<>();


### PR DESCRIPTION
I noticed there was no test for the attempted deletion of a batch that did not exist so added it here. @andyreidz Can you have a look to see if this is ok?
Dev build: http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/view/Developer/job/CAFDataProcessing~staging-service~delete_test~CI