### PR TITLE
SCMOD-6980: uploaded files are now renamed using UUID

### DIFF
--- a/staging-service-acceptance-tests/src/test/java/com/github/cafdataprocessing/services/staging/StagingServiceLinuxIT.java
+++ b/staging-service-acceptance-tests/src/test/java/com/github/cafdataprocessing/services/staging/StagingServiceLinuxIT.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2015-2018 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafdataprocessing.services.staging;
+
+import com.github.cafdataprocessing.services.staging.client.ApiClient;
+import com.github.cafdataprocessing.services.staging.client.ApiException;
+import com.github.cafdataprocessing.services.staging.client.MultiPart;
+import com.github.cafdataprocessing.services.staging.client.MultiPartContent;
+import com.github.cafdataprocessing.services.staging.client.MultiPartDocument;
+import com.github.cafdataprocessing.services.staging.client.StagingApi;
+import com.github.cafdataprocessing.services.staging.client.StagingBatchList;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StagingServiceLinuxIT
+{
+    private static final String STAGING_SERVICE_URI = System.getenv("staging-service");
+    //private static final String STAGING_SERVICE_URI = "http://192.168.56.10:8080";
+    private final StagingApi stagingApi;
+
+    public StagingServiceLinuxIT()
+    {
+        final ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(STAGING_SERVICE_URI);
+        stagingApi = new StagingApi();
+        stagingApi.setApiClient(apiClient);
+    }
+
+    @Before
+    public void linuxOnly()
+    {
+        assumeTrue(SystemUtils.IS_OS_LINUX);
+        System.out.println("Linux Tests");
+    }
+
+    @Test
+    public void uploadLinuxPathTest() throws Exception
+    {
+        final String tenantId = "tenant-linux1";
+        final String file1AbsolutePath = Paths.get("src", "test", "resources", "A_Christmas_Carol1.txt").toAbsolutePath().toString();
+        final String file2AbsolutePath = Paths.get("src", "test", "resources", "A_Christmas_Carol2.txt").toAbsolutePath().toString();
+        final String[] contentFiles = new String[]{file1AbsolutePath, file2AbsolutePath};
+        final StringBuilder document = new StringBuilder("{\n"
+            + "  \"document\": {\n"
+            + "    \"reference\": \"fav-book.msg\",\n"
+            + "    \"fields\": {\n"
+            + "      \"FROM\": [{\"data\": \"Mark Roberts\"}],\n"
+            + "      \"TO\": [{\"data\": \"Gene Simmons\"}],\n"
+            + "      \"SUBJECT\": [{\"data\": \"Favourite book\"}],\n"
+            + "      \"CONTENT\": [{\"data\": \"This is the book that popularised the use of the phrase \\\"Merry Christmas\\\".\"}]\n"
+            + "    },\n"
+            + "    \"subdocuments\": [{\n"
+            + "      \"reference\": \"xmas-carol.doc\",\n"
+            + "      \"fields\": {\n"
+            + "        \"BINARY_FILE\": [{\n"
+            + "           \"data\": \"http://www.lang.nagoya-u.ac.jp/~matsuoka/misc/urban/cd-carol.doc\",\n"
+            + "           \"encoding\": \"storage_ref\"\n"
+            + "          }],\n"
+            + "        \"TITLE\": [{\"data\": \"A Christmas Carol\"}],\n"
+            + "        \"AUTHOR\": [{\"data\": \"Charles Dickens\"}],\n"
+            + "        \"PUB_DATE\": [{\"data\": \"December 19, 1843\"}],\n"
+            + "        \"CONTENT\": [{\n"
+            + "           \"data\": \"");
+        document.append(file1AbsolutePath);
+        document.append("\",\n"
+            + "           \"encoding\": \"local_ref\"\n"
+            + "          }],\n"
+            + "        \"SUMMARY\": [{\n"
+            + "            \"encoding\": \"local_ref\",\n"
+            + "            \"data\": \"");
+        document.append(file2AbsolutePath);
+        document.append("\"\n"
+            + "          }],\n"
+            + "        \"PUBLISHER\": [\n"
+            + "          {\"data\": \"Chapman and Hall\"},\n"
+            + "          {\"data\": \"Elliot Stock\"}\n"
+            + "        ]\n"
+            + "      }\n"
+            + "    }]\n"
+            + "  }\n"
+            + "}");
+
+        System.out.println("Document prepared:\n" + document.toString());
+        final String[] documentFiles = new String[]{document.toString()};
+        final String batchId = "testBatch1";
+        stageMultiParts(tenantId, batchId, contentFiles, documentFiles);
+        final StagingBatchList response = stagingApi.getBatches(tenantId, batchId, batchId, 10);
+        assertTrue("uploadDocumentsToBatchTest, 1 batch uploaded", response.getEntries().size() == 1);
+    }
+
+    @Test
+    public void uploadLinuxDangerousPathsTest() throws Exception
+    {
+        final String tenantId = "tenant-linux2";
+        final String file1AbsolutePath = Paths.get("src", "test", "resources", "A_Christmas_Carol1.txt").toAbsolutePath().toString();
+        final String file2AbsolutePath = Paths.get("src", "test", "resources", "A_Christmas_Carol2.txt").toAbsolutePath().toString();
+        final String[] contentFiles = new String[]{file1AbsolutePath, file2AbsolutePath};
+        final StringBuilder document = new StringBuilder("{\n"
+            + "  \"document\": {\n"
+            + "    \"reference\": \"fav-book.msg\",\n"
+            + "    \"fields\": {\n"
+            + "      \"FROM\": [{\"data\": \"Mark Roberts\"}],\n"
+            + "      \"TO\": [{\"data\": \"Gene Simmons\"}],\n"
+            + "      \"SUBJECT\": [{\"data\": \"Favourite book\"}],\n"
+            + "      \"CONTENT\": [{\"data\": \"This is the book that popularised the use of the phrase \\\"Merry Christmas\\\".\"}]\n"
+            + "    },\n"
+            + "    \"subdocuments\": [{\n"
+            + "      \"reference\": \"xmas-carol.doc\",\n"
+            + "      \"fields\": {\n"
+            + "        \"BINARY_FILE\": [{\n"
+            + "           \"data\": \"http://www.lang.nagoya-u.ac.jp/~matsuoka/misc/urban/cd-carol.doc\",\n"
+            + "           \"encoding\": \"storage_ref\"\n"
+            + "          }],\n"
+            + "        \"TITLE\": [{\"data\": \"A Christmas Carol\"}],\n"
+            + "        \"AUTHOR\": [{\"data\": \"Charles Dickens\"}],\n"
+            + "        \"PUB_DATE\": [{\"data\": \"December 19, 1843\"}],\n"
+            + "        \"CONTENT\": [{\n"
+            + "           \"data\": \"");
+        document.append("/etc/passwd");
+        document.append("\",\n"
+            + "           \"encoding\": \"local_ref\"\n"
+            + "          }],\n"
+            + "        \"SUMMARY\": [{\n"
+            + "            \"encoding\": \"local_ref\",\n"
+            + "            \"data\": \"");
+        document.append("/usr/share/terminfo/h");
+        document.append("\"\n"
+            + "          }],\n"
+            + "        \"PUBLISHER\": [\n"
+            + "          {\"data\": \"Chapman and Hall\"},\n"
+            + "          {\"data\": \"Elliot Stock\"}\n"
+            + "        ]\n"
+            + "      }\n"
+            + "    }]\n"
+            + "  }\n"
+            + "}");
+
+        System.out.println("Document prepared:\n" + document.toString());
+        final String[] documentFiles = new String[]{document.toString()};
+        final String batchId = "testBatch2";
+        try {
+            stageMultiParts(tenantId, batchId, contentFiles, documentFiles);
+            fail("An exception should have been thrown");
+        } catch (ApiException ex) {
+            assertEquals(400, ex.getCode());
+        }
+    }
+
+    private void stageMultiParts(final String tenantId, final String batchId, final String[] contentFiles, final String[] documentFiles)
+        throws IOException, ApiException
+    {
+        final List<MultiPart> uploadData = new ArrayList<>();
+        for (final String file : contentFiles) {
+            System.out.println("File: " + file);
+            uploadData.add(new MultiPartContent(file, () -> new FileInputStream(file)));
+        }
+        for (final String file : documentFiles) {
+            File documentFile = Files.createTempFile(Files.createTempDirectory("docBase"), "doc-", ".json").toFile();
+            documentFile.deleteOnExit();
+            System.out.println("Document: " + documentFile);
+            FileUtils.copyInputStreamToFile(new ByteArrayInputStream(file.getBytes()), documentFile);
+            uploadData.add(new MultiPartDocument(documentFile));
+        }
+        stagingApi.createOrReplaceBatch(tenantId, batchId, uploadData.stream());
+    }
+}

--- a/staging-service-acceptance-tests/src/test/java/com/github/cafdataprocessing/services/staging/StagingServiceWindowsIT.java
+++ b/staging-service-acceptance-tests/src/test/java/com/github/cafdataprocessing/services/staging/StagingServiceWindowsIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2015-2018 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cafdataprocessing.services.staging;
+
+import com.github.cafdataprocessing.services.staging.client.ApiClient;
+import com.github.cafdataprocessing.services.staging.client.ApiException;
+import com.github.cafdataprocessing.services.staging.client.MultiPart;
+import com.github.cafdataprocessing.services.staging.client.MultiPartContent;
+import com.github.cafdataprocessing.services.staging.client.MultiPartDocument;
+import com.github.cafdataprocessing.services.staging.client.StagingApi;
+import com.github.cafdataprocessing.services.staging.client.StagingBatchList;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StagingServiceWindowsIT
+{
+    private static final String STAGING_SERVICE_URI = System.getenv("staging-service");
+    //private static final String STAGING_SERVICE_URI = "http://192.168.56.10:8080";
+    private final StagingApi stagingApi;
+
+    public StagingServiceWindowsIT()
+    {
+        final ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(STAGING_SERVICE_URI);
+        stagingApi = new StagingApi();
+        stagingApi.setApiClient(apiClient);
+    }
+
+    @Before
+    public void windowsOnly()
+    {
+        assumeTrue(SystemUtils.IS_OS_WINDOWS);
+        System.out.println("Windows Tests");
+    }
+
+    @Test
+    public void uploadWindowsPathTest() throws Exception
+    {
+        final String tenantId = "tenant-windows1";
+        final String file1AbsolutePath = Paths.get("src", "test", "resources", "A_Christmas_Carol1.txt").toAbsolutePath().toString();
+        final String file2AbsolutePath = Paths.get("src", "test", "resources", "A_Christmas_Carol2.txt").toAbsolutePath().toString();
+        final String[] contentFiles = new String[]{file1AbsolutePath, file2AbsolutePath};
+        final StringBuilder document = new StringBuilder("{\n"
+            + "  \"document\": {\n"
+            + "    \"reference\": \"fav-book.msg\",\n"
+            + "    \"fields\": {\n"
+            + "      \"FROM\": [{\"data\": \"Mark Roberts\"}],\n"
+            + "      \"TO\": [{\"data\": \"Gene Simmons\"}],\n"
+            + "      \"SUBJECT\": [{\"data\": \"Favourite book\"}],\n"
+            + "      \"CONTENT\": [{\"data\": \"This is the book that popularised the use of the phrase \\\"Merry Christmas\\\".\"}]\n"
+            + "    },\n"
+            + "    \"subdocuments\": [{\n"
+            + "      \"reference\": \"xmas-carol.doc\",\n"
+            + "      \"fields\": {\n"
+            + "        \"BINARY_FILE\": [{\n"
+            + "           \"data\": \"http://www.lang.nagoya-u.ac.jp/~matsuoka/misc/urban/cd-carol.doc\",\n"
+            + "           \"encoding\": \"storage_ref\"\n"
+            + "          }],\n"
+            + "        \"TITLE\": [{\"data\": \"A Christmas Carol\"}],\n"
+            + "        \"AUTHOR\": [{\"data\": \"Charles Dickens\"}],\n"
+            + "        \"PUB_DATE\": [{\"data\": \"December 19, 1843\"}],\n"
+            + "        \"CONTENT\": [{\n"
+            + "           \"data\": \"");
+        document.append(file1AbsolutePath.replaceAll("\\\\", "\\\\\\\\"));
+        document.append("\",\n"
+            + "           \"encoding\": \"local_ref\"\n"
+            + "          }],\n"
+            + "        \"SUMMARY\": [{\n"
+            + "            \"encoding\": \"local_ref\",\n"
+            + "            \"data\": \"");
+        document.append(file2AbsolutePath.replaceAll("\\\\", "\\\\\\\\"));
+        document.append("\"\n"
+            + "          }],\n"
+            + "        \"PUBLISHER\": [\n"
+            + "          {\"data\": \"Chapman and Hall\"},\n"
+            + "          {\"data\": \"Elliot Stock\"}\n"
+            + "        ]\n"
+            + "      }\n"
+            + "    }]\n"
+            + "  }\n"
+            + "}");
+
+        System.out.println("Document prepared:\n" + document.toString());
+        final String[] documentFiles = new String[]{document.toString()};
+        final String batchId = "testBatch1";
+        stageMultiParts(tenantId, batchId, contentFiles, documentFiles);
+        final StagingBatchList response = stagingApi.getBatches(tenantId, batchId, batchId, 10);
+        assertTrue("uploadDocumentsToBatchTest, 1 batch uploaded", response.getEntries().size() == 1);
+    }
+
+    private void stageMultiParts(final String tenantId, final String batchId, final String[] contentFiles, final String[] documentFiles)
+        throws IOException, ApiException
+    {
+        final List<MultiPart> uploadData = new ArrayList<>();
+        for (final String file : contentFiles) {
+            uploadData.add(new MultiPartContent(file, () -> new FileInputStream(file)));
+        }
+        for (final String file : documentFiles) {
+            File documentFile = Files.createTempFile(Files.createTempDirectory("docBase"), "doc-", ".json").toFile();
+            documentFile.deleteOnExit();
+            FileUtils.copyInputStreamToFile(new ByteArrayInputStream(file.getBytes()), documentFile);
+            uploadData.add(new MultiPartDocument(documentFile));
+        }
+        stagingApi.createOrReplaceBatch(tenantId, batchId, uploadData.stream());
+    }
+}

--- a/staging-service/src/main/java/com/github/cafdataprocessing/services/staging/dao/filesystem/SubBatchWriter.java
+++ b/staging-service/src/main/java/com/github/cafdataprocessing/services/staging/dao/filesystem/SubBatchWriter.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.cafdataprocessing.services.staging.utils.JsonMinifier;
 import com.microfocus.caf.worker.document.schema.validator.InvalidDocumentException;
-import java.util.Set;
+import java.util.Map;
 
 /*
  * This class handles the sub-batching and storing of documents.
@@ -79,7 +79,7 @@ public class SubBatchWriter implements AutoCloseable {
                                   final String storageRefFolderPath,
                                   final String inprogressContentFolderPath,
                                   final int fieldValueSizeThreshold,
-                                  final Set<String> binaryFilesUploaded)
+                                  final Map<String, String> binaryFilesUploaded)
             throws StagingException, InvalidBatchException, IncompleteBatchException {
 
         if(count >= subbatchSize)

--- a/staging-service/src/test/java/com/github/cafdataprocessing/services/staging/utils/JsonMinifierTest.java
+++ b/staging-service/src/test/java/com/github/cafdataprocessing/services/staging/utils/JsonMinifierTest.java
@@ -25,9 +25,7 @@ import java.io.InputStream;
 import org.junit.Test;
 
 import com.microfocus.caf.worker.document.schema.validator.InvalidDocumentException;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.UUID;
 
@@ -36,6 +34,7 @@ public final class JsonMinifierTest {
     final String inprogressContentFolderPath = "/etc/store/batches/acme-com/in_progress/test_batch/files";
     final int fieldValueSizeThreshold = 8192; // 8KB
 
+    @SuppressWarnings("serial")
     @Test
     public void minifyJsonTest() throws Exception {
         System.out.println("minifyJsonTest...");
@@ -134,6 +133,7 @@ public final class JsonMinifierTest {
         assertTrue("minifyStorageRefJsonTest", !minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
     }
 
+    @SuppressWarnings("serial")
     @Test
     public void minifyLocalRefJsonTest() throws Exception {
         System.out.println("minifyLocalRefJsonTest...");
@@ -173,6 +173,7 @@ public final class JsonMinifierTest {
         assertTrue("minifyLocalRefJsonTest", minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
     }
     
+    @SuppressWarnings("serial")
     @Test
     public void storageAndLocalRefFirstTest() throws Exception {
         System.out.println("minifyLocalRefJsonTest...");
@@ -317,6 +318,7 @@ public final class JsonMinifierTest {
         }
     }
 
+    @SuppressWarnings("serial")
     @Test
     public void validateAndMinifyJsonTest() throws Exception {
         System.out.println("validateAndMinifyJsonTest...");
@@ -415,6 +417,7 @@ public final class JsonMinifierTest {
         assertTrue("validateAndMinifyStorageRefJsonTest", !minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
     }
 
+    @SuppressWarnings("serial")
     @Test
     public void validateAndMinifyLocalRefJsonTest() throws Exception {
         System.out.println("validateAndMinifyLocalRefJsonTest...");
@@ -559,6 +562,7 @@ public final class JsonMinifierTest {
         assertTrue("validateAndMinifyNoRefMultiValueJsonTest", !minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
     }
 
+    @SuppressWarnings("serial")
     @Test
     public void validateAndMinifyLocalRefMultiValueJsonTest() throws Exception {
         System.out.println("validateAndMinifyLocalRefMultiValueJsonTest...");
@@ -593,6 +597,7 @@ public final class JsonMinifierTest {
         assertTrue("validateAndMinifyLocalRefMultiValueJsonTest", minifiedJson.contains("\"PUBLISHER\":[{\"data\":\"Chapman and Hall\"}"));
     }
 
+    @SuppressWarnings("serial")
     @Test
     public void minifyLargeDataJsonTest() throws Exception {
         System.out.println("minifyLargeDataJsonTest...");
@@ -612,6 +617,7 @@ public final class JsonMinifierTest {
         assertTrue("minifyLargeDataJsonTest", minifiedJson.contains("\"SUBJECT\":[{\"data\":\"/etc/store/batches/acme-com/completed/test_batch/files/"));
     }
 
+    @SuppressWarnings("serial")
     @Test
     public void minifyLargeBase64DataJsonTest() throws Exception {
         System.out.println("minifyLargeBase64DataJsonTest...");

--- a/staging-service/src/test/java/com/github/cafdataprocessing/services/staging/utils/JsonMinifierTest.java
+++ b/staging-service/src/test/java/com/github/cafdataprocessing/services/staging/utils/JsonMinifierTest.java
@@ -26,7 +26,10 @@ import org.junit.Test;
 
 import com.microfocus.caf.worker.document.schema.validator.InvalidDocumentException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.UUID;
 
 public final class JsonMinifierTest {
 
@@ -38,9 +41,15 @@ public final class JsonMinifierTest {
         System.out.println("minifyJsonTest...");
         final InputStream inputStream = JsonMinifierTest.class.getResource("/batch1.json").openStream();
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final Map<String, String> map = new HashMap<String, String>()
+        {
+            {
+                put("A_Christmas_Carol1.txt", UUID.randomUUID().toString());
+                put("A_Christmas_Carol2.txt", UUID.randomUUID().toString());
+            }
+        };
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                                inprogressContentFolderPath, fieldValueSizeThreshold,
-                                new HashSet<>(Arrays.asList("A_Christmas_Carol1.txt", "A_Christmas_Carol2.txt")));
+                                inprogressContentFolderPath, fieldValueSizeThreshold, map);
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("minifyJsonTest : Minified Json : " + minifiedJson);
         assertTrue("minifyJsonTest", minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
@@ -90,7 +99,7 @@ public final class JsonMinifierTest {
         final InputStream inputStream = new ByteArrayInputStream(testJson.getBytes("UTF-8"));
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold, new HashSet<>());
+                inprogressContentFolderPath, fieldValueSizeThreshold, new HashMap<>());
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("minifyUTFEncodingOnlyJsonTest : Minified Json : " + minifiedJson);
         assertTrue("minifyUTFEncodingOnlyJsonTest", !minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
@@ -151,8 +160,14 @@ public final class JsonMinifierTest {
         testJson = testJson.replaceAll("'", "\"");
         final InputStream inputStream = new ByteArrayInputStream(testJson.getBytes("UTF-8"));
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final Map<String, String> map = new HashMap<String, String>()
+        {
+            {
+                put("Front_Cover.jpg", UUID.randomUUID().toString());
+            }
+        };
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold, new HashSet<>(Arrays.asList("Front_Cover.jpg")));
+                inprogressContentFolderPath, fieldValueSizeThreshold, map);
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("minifyLocalRefJsonTest : Minified Json : " + minifiedJson);
         assertTrue("minifyLocalRefJsonTest", minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
@@ -180,8 +195,14 @@ public final class JsonMinifierTest {
         testJson = testJson.replaceAll("'", "\"");
         final InputStream inputStream = new ByteArrayInputStream(testJson.getBytes("UTF-8"));
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final Map<String, String> map = new HashMap<String, String>()
+        {
+            {
+                put("Front_Cover.jpg", UUID.randomUUID().toString());
+            }
+        };
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold, new HashSet<>(Arrays.asList("Front_Cover.jpg")));
+                inprogressContentFolderPath, fieldValueSizeThreshold, map);
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("minifyLocalRefJsonTest : Minified Json : " + minifiedJson);
         assertTrue("minifyLocalRefJsonTest", minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
@@ -236,7 +257,7 @@ public final class JsonMinifierTest {
         final InputStream inputStream = new ByteArrayInputStream(testJson.getBytes("UTF-8"));
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold, new HashSet<>());
+                inprogressContentFolderPath, fieldValueSizeThreshold, new HashMap<>());
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("minifyBase64EncodingJsonTest : Minified Json : " + minifiedJson);
         assertTrue("minifyBase64EncodingJsonTest", minifiedJson.contains("base64"));
@@ -301,9 +322,15 @@ public final class JsonMinifierTest {
         System.out.println("validateAndMinifyJsonTest...");
         final InputStream inputStream = JsonMinifierTest.class.getResource("/batch1.json").openStream();
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final Map<String, String> map = new HashMap<String, String>()
+        {
+            {
+                put("A_Christmas_Carol1.txt", UUID.randomUUID().toString());
+                put("A_Christmas_Carol2.txt", UUID.randomUUID().toString());
+            }
+        };
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold, 
-                new HashSet<>(Arrays.asList("A_Christmas_Carol1.txt", "A_Christmas_Carol2.txt")));
+                inprogressContentFolderPath, fieldValueSizeThreshold, map);
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("validateAndMinifyJsonTest : Minified Json : " + minifiedJson);
         assertTrue("validateAndMinifyJsonTest", minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
@@ -414,8 +441,14 @@ public final class JsonMinifierTest {
         testJson = testJson.replaceAll("'", "\"");
         final InputStream inputStream = new ByteArrayInputStream(testJson.getBytes("UTF-8"));
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final Map<String, String> map = new HashMap<String, String>()
+        {
+            {
+                put("Front_Cover.jpg", UUID.randomUUID().toString());
+            }
+        };
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold, new HashSet<>(Arrays.asList("Front_Cover.jpg")));
+                inprogressContentFolderPath, fieldValueSizeThreshold, map);
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("validateAndMinifyLocalRefJsonTest : Minified Json : " + minifiedJson);
         assertTrue("validateAndMinifyLocalRefJsonTest", minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
@@ -546,8 +579,14 @@ public final class JsonMinifierTest {
         testJson = testJson.replaceAll("'", "\"");
         final InputStream inputStream = new ByteArrayInputStream(testJson.getBytes("UTF-8"));
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final Map<String, String> map = new HashMap<String, String>()
+        {
+            {
+                put("A_Christmas_Carol2.txt", UUID.randomUUID().toString());
+            }
+        };
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold, new HashSet<>(Arrays.asList("A_Christmas_Carol2.txt")));
+                inprogressContentFolderPath, fieldValueSizeThreshold, map);
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("validateAndMinifyLocalRefMultiValueJsonTest : Minified Json : " + minifiedJson);
         assertTrue("validateAndMinifyLocalRefMultiValueJsonTest", minifiedJson.contains("/etc/store/batches/acme-com/completed/test_batch/files"));
@@ -559,9 +598,15 @@ public final class JsonMinifierTest {
         System.out.println("minifyLargeDataJsonTest...");
         final InputStream inputStream = JsonMinifierTest.class.getResource("/largeDataBatch.json").openStream();
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final Map<String, String> map = new HashMap<String, String>()
+        {
+            {
+                put("A_Christmas_Carol1.txt", UUID.randomUUID().toString());
+                put("A_Christmas_Carol2.txt", UUID.randomUUID().toString());
+            }
+        };
         JsonMinifier.minifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold, 
-                new HashSet<>(Arrays.asList("A_Christmas_Carol1.txt", "A_Christmas_Carol2.txt")));
+                inprogressContentFolderPath, fieldValueSizeThreshold, map);
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("minifyLargeDataJsonTest : Minified Json : " + minifiedJson);
         assertTrue("minifyLargeDataJsonTest", minifiedJson.contains("\"SUBJECT\":[{\"data\":\"/etc/store/batches/acme-com/completed/test_batch/files/"));
@@ -572,9 +617,15 @@ public final class JsonMinifierTest {
         System.out.println("minifyLargeBase64DataJsonTest...");
         final InputStream inputStream = JsonMinifierTest.class.getResource("/largeBase64DataBatch.json").openStream();
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final Map<String, String> map = new HashMap<String, String>()
+        {
+            {
+                put("A_Christmas_Carol1.txt", UUID.randomUUID().toString());
+                put("A_Christmas_Carol2.txt", UUID.randomUUID().toString());
+            }
+        };
         JsonMinifier.validateAndMinifyJson(inputStream, outStream, "/etc/store/batches/acme-com/completed/test_batch/files",
-                inprogressContentFolderPath, fieldValueSizeThreshold,
-                new HashSet<>(Arrays.asList("A_Christmas_Carol1.txt", "A_Christmas_Carol2.txt")));
+                inprogressContentFolderPath, fieldValueSizeThreshold, map);
         final String minifiedJson = outStream.toString("UTF-8");
         System.out.println("minifyLargeBase64DataJsonTest : Minified Json : " + minifiedJson);
         assertTrue("minifyLargeBase64DataJsonTest", minifiedJson.contains("\"COVER_PIC\":[{\"data\":\"/etc/store/batches/acme-com/completed/test_batch/files"));


### PR DESCRIPTION
## Jira

https://portal.digitalsafe.net/browse/SCMOD-6980

## Build

http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/job/CAFDataProcessing%7Estaging-service%7ESCMOD-6980%7ECI/

## Notes

If the file staged was represented using a path, on Linux, this could have meant that workers down the line would have not been able to retrieve the file, because the path was incorrect. The modifications here are meant to use UUID for all the files uploaded.
