### PR TITLE
616155: Update Ingestion Batch Worker to add QoQ support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <enforceCorrectDependencies>true</enforceCorrectDependencies>
         <fasterxmlVersion>2.12.5</fasterxmlVersion>
         <springDataVersion>2.0.9.RELEASE</springDataVersion>
-        <caf.worker-batch-framework.version>3.7.0-616155-SNAPSHOT</caf.worker-batch-framework.version>
+        <caf.worker-batch-framework.version>3.7.0-SNAPSHOT</caf.worker-batch-framework.version>
         <fabric8.docker.maven.version>0.37.0</fabric8.docker.maven.version>
         <junit.jupiter.version>5.4.1</junit.jupiter.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <junit.jupiter.version>5.4.1</junit.jupiter.version>
         <hamcrest.version>1.3</hamcrest.version>
         <lombok.version>1.18.6</lombok.version>
-        <worker-document.version>5.2.0-US616155-SNAPSHOT</worker-document.version>
+        <worker-document.version>5.1.0-1038</worker-document.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <enforceCorrectDependencies>true</enforceCorrectDependencies>
         <fasterxmlVersion>2.12.5</fasterxmlVersion>
         <springDataVersion>2.0.9.RELEASE</springDataVersion>
-        <caf.worker-batch-framework.version>3.6.0-88</caf.worker-batch-framework.version>
+        <caf.worker-batch-framework.version>3.7.0-616155-SNAPSHOT</caf.worker-batch-framework.version>
         <fabric8.docker.maven.version>0.37.0</fabric8.docker.maven.version>
         <junit.jupiter.version>5.4.1</junit.jupiter.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <junit.jupiter.version>5.4.1</junit.jupiter.version>
         <hamcrest.version>1.3</hamcrest.version>
         <lombok.version>1.18.6</lombok.version>
-        <worker-document.version>5.1.0-1038</worker-document.version>
+        <worker-document.version>5.2.0-US616155-SNAPSHOT</worker-document.version>
     </properties>
 
     <dependencyManagement>

--- a/release-notes-2.1.0.md
+++ b/release-notes-2.1.0.md
@@ -4,5 +4,15 @@
 ${version-number}
 
 #### New Features
+- US616155: This worker now supports message prioritization.  
+
+  Messages intended for this worker can be redirected to one or more staging queues instead of the worker's target queue. This feature
+  can be enabled by setting the `CAF_WORKER_ENABLE_DIVERTED_TASK_CHECKING` environment variable to `false` on **this worker**, and
+  setting the `CAF_WMP_ENABLED` environment variable to `true` on the **worker that routes messages to this worker**.   
+
+  The `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE` environment variable (default: `false`) determines whether a worker should use the
+  target queue's capacity when making a decision on whether to reroute a message. This should be set on the **worker that routes messages
+  to this worker**. If `true`, a message will only be rerouted to a staging queue if the target queue does not have capacity for it. If
+  `false`, a message will **always** be rerouted to a staging queue, irregardless of the target queue's capacity.
 
 #### Known Issues

--- a/release-notes-2.1.0.md
+++ b/release-notes-2.1.0.md
@@ -6,13 +6,13 @@ ${version-number}
 #### New Features
 - US616155: This worker now supports message prioritization.  
 
-  Messages intended for this worker can be redirected to one or more staging queues instead of the worker's target queue. This feature
-  can be enabled by setting the `CAF_WORKER_ENABLE_DIVERTED_TASK_CHECKING` environment variable to `false` on **this worker**, and
-  setting the `CAF_WMP_ENABLED` environment variable to `true` on the **worker that routes messages to this worker**.   
+  Messages intended for this worker can be redirected to one or more staging queues instead of the worker's target queue.  This feature can be enabled by setting the `CAF_WORKER_ENABLE_DIVERTED_TASK_CHECKING` environment variable to `false` on **this worker**, and setting the `CAF_WMP_ENABLED` environment variable to `true` on the **component that routes messages to this worker**.   
 
-  The `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE` environment variable (default: `false`) determines whether a worker should use the
-  target queue's capacity when making a decision on whether to reroute a message. This should be set on the **worker that routes messages
-  to this worker**. If `true`, a message will only be rerouted to a staging queue if the target queue does not have capacity for it. If
-  `false`, a message will **always** be rerouted to a staging queue, irregardless of the target queue's capacity.
+  The `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE` environment variable (default: `false`) determines whether this worker's target queue capacity should be considered when making a decision on whether to reroute a message. This should be set on the **component that routes messages to this worker**.
+If `true`, a message will only be rerouted to a staging queue if the target queue does not have capacity for it. If `false`, a message will **always** be rerouted to a staging queue, ignoring the target queue's capacity.
+
+  The `CAF_WMP_KUBERNETES_NAMESPACES` environment variable used to specify the Kubernetes namespaces, comma separated, in which to search for this worker's labels.  This should be set on the **component that routes messages to this worker**. These labels contain information this worker's target queue, such as its name and maximum length. A non-null and non-empty value must be provided for this environment variable if `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE` is true. If `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE` is false, this environment variable is not used.  
+
+  The `CAF_WMP_KUBERNETES_LABEL_CACHE_EXPIRY_MINUTES` (default: `60`) is used to specify the 'expire after write' minutes after which a Kubernetes label that has been added to the cache should be removed. This should be set on the **component that routes messages to this worker**. Set this to 0 to disable caching. Only used when `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE` is true. If `CAF_WMP_USE_TARGET_QUEUE_CAPACITY_TO_REROUTE` is false, this environment variable is not used.  
 
 #### Known Issues

--- a/worker-batch-ingestion-container/pom.xml
+++ b/worker-batch-ingestion-container/pom.xml
@@ -269,13 +269,13 @@
                             <goal>start</goal>
                         </goals>
                     </execution>
-<!--                    <execution>-->
-<!--                        <id>stop</id>-->
-<!--                        <phase>post-integration-test</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>stop</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
                     <execution>
                         <id>upload-docker-container</id>
                         <phase>deploy</phase>

--- a/worker-batch-ingestion-container/pom.xml
+++ b/worker-batch-ingestion-container/pom.xml
@@ -269,13 +269,13 @@
                             <goal>start</goal>
                         </goals>
                     </execution>
-                    <execution>
-                        <id>stop</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
+<!--                    <execution>-->
+<!--                        <id>stop</id>-->
+<!--                        <phase>post-integration-test</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>stop</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
                     <execution>
                         <id>upload-docker-container</id>
                         <phase>deploy</phase>
@@ -475,6 +475,8 @@
                                     <CAF_RABBITMQ_USERNAME>guest</CAF_RABBITMQ_USERNAME>
                                     <CAF_RABBITMQ_PASSWORD>guest</CAF_RABBITMQ_PASSWORD>
                                     <CAF_WORKER_INPUT_QUEUE>ingestion-batch-in</CAF_WORKER_INPUT_QUEUE>
+                                    <CAF_LOG_LEVEL>DEBUG</CAF_LOG_LEVEL>
+                                    <CAF_WORKER_ENABLE_DIVERTED_TASK_CHECKING>false</CAF_WORKER_ENABLE_DIVERTED_TASK_CHECKING>
                                 </env>
                                 <volumes>
                                     <from>

--- a/worker-batch-ingestion-container/pom.xml
+++ b/worker-batch-ingestion-container/pom.xml
@@ -475,8 +475,6 @@
                                     <CAF_RABBITMQ_USERNAME>guest</CAF_RABBITMQ_USERNAME>
                                     <CAF_RABBITMQ_PASSWORD>guest</CAF_RABBITMQ_PASSWORD>
                                     <CAF_WORKER_INPUT_QUEUE>ingestion-batch-in</CAF_WORKER_INPUT_QUEUE>
-                                    <CAF_LOG_LEVEL>DEBUG</CAF_LOG_LEVEL>
-                                    <CAF_WORKER_ENABLE_DIVERTED_TASK_CHECKING>false</CAF_WORKER_ENABLE_DIVERTED_TASK_CHECKING>
                                 </env>
                                 <volumes>
                                     <from>

--- a/worker-batch-ingestion-plugin/pom.xml
+++ b/worker-batch-ingestion-plugin/pom.xml
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>com.github.cafdataprocessing</groupId>
                 <artifactId>worker-document-shared</artifactId>
-                <version>5.0.0-924</version>
+                <version>5.2.0-US616155-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/worker-batch-ingestion-plugin/pom.xml
+++ b/worker-batch-ingestion-plugin/pom.xml
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>com.github.cafdataprocessing</groupId>
                 <artifactId>worker-document-shared</artifactId>
-                <version>5.2.0-US616155-SNAPSHOT</version>
+                <version>5.2.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=616155

The Batch Ingestion Worker needs to support QoQ, see Michael's findings on [616155](https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=616155):

> During a test run of a large and medium ingestion job on the Eval system I stopped ingestion batch worker so that all messages could be queued up. Using the job service poc build I could see that all messages went into the staging queues for ingestion batch which is good. However when I started ingestion batch back up all messages were processed and sent into the main queue for app resources worker and the staging queues were not utilized. I am seeing the large job seems to be progressing but I have so far not see any messages for the medium job hit their staging queues so not sure if this is due to the large number of messages in the app resources worker queue. I did notice that neither ingestion batch or app resource worker have this functionality enabled so maybe we are missing something there?