### PR TITLE
I884207: Reorder build modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,10 @@
         <module>staging-service</module>
         <module>staging-service-container</module>
         <module>staging-service-internal-client</module>
-        <module>staging-service-acceptance-tests</module>
         <module>worker-batch-ingestion-plugin</module>
         <module>worker-batch-ingestion-container</module>
         <module>worker-batch-ingestion-container-testing</module>
+        <module>staging-service-acceptance-tests</module>
     </modules>
 
     <parent>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=884207

In commit [dc2dd89](https://github.com/CAFDataProcessing/staging-service/pull/173/commits/dc2dd89d6a838eb1a5d77f4a239e54ad9bcb4840), we had set `skipNexusStagingDeployMojo` property to `true` so we can skip deployment of `worker-batch-ingestion-container-testing`. 

But as per the [documentation](https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md), if skipNexusStagingDeployMojo  is set to true in the last module, it skips the staging for all modules.

> Completely skips the deploy Mojo (similar as maven.deploy.skip). In multi-module builds using the deploy-at-end feature, the deployment of all components is performed in the last module based on the reactor order. If this property is set to true in the last module, all staging deployment for all modules will be skipped. In some cases, it may be necessary to add a dummy module.

So, in this PR I have reordered the module executions, so we have a 'deployable' module after the skipped module.
