### PR TITLE
US919158: Split out liveness + readiness checks

### DIFF
--- a/release-notes-3.2.0.md
+++ b/release-notes-3.2.0.md
@@ -4,5 +4,8 @@
 ${version-number}
 
 #### New Features
+- US919158: The `healthcheck` endpoint now supports the `/liveness` and `/readiness` paths to check if the service is alive/ready.
+  - The `healthcheck/liveness` endpoint checks: livenessState,diskAccess
+  - The `healthcheck/readiness` endpoint checks: livenessState,diskAccess,readinessState,ping
 
 #### Known Issues

--- a/staging-service-acceptance-tests/pom.xml
+++ b/staging-service-acceptance-tests/pom.xml
@@ -192,7 +192,7 @@
                                 </log>
                                 <wait>
                                     <http>
-                                        <url>http://${docker.host.address}:${staging.ports.api.admin}/healthcheck</url>
+                                        <url>http://${docker.host.address}:${staging.ports.api.admin}/healthcheck/readiness</url>
                                     </http>
                                     <time>120000</time>
                                     <shutdown>500</shutdown>

--- a/staging-service/src/main/resources/application.yaml
+++ b/staging-service/src/main/resources/application.yaml
@@ -20,11 +20,6 @@ server:
 https:
   port: 8443
 management:
-  health:
-    livenessState:
-      enabled: true
-    readinessState:
-      enabled: true
   server:
     port: 8081
   endpoints:
@@ -58,6 +53,10 @@ management:
   health:
     diskspace:
       enabled: false
+    livenessState:
+      enabled: true
+    readinessState:
+      enabled: true
 # Spring does not support streaming multipart request bodies, so we must use commons-fileupload2 instead. To prevent Spring from reading
 # the request body we are setting `spring.servlet.multipart.enabled=false` in the application.yaml
 #

--- a/staging-service/src/main/resources/application.yaml
+++ b/staging-service/src/main/resources/application.yaml
@@ -20,6 +20,11 @@ server:
 https:
   port: 8443
 management:
+  health:
+    livenessState:
+      enabled: true
+    readinessState:
+      enabled: true
   server:
     port: 8081
   endpoints:
@@ -36,6 +41,14 @@ management:
   endpoint:
     health:
       show-details: ALWAYS
+      probes:
+        enabled: true
+      group:
+        liveness:
+          include: livenessState,
+        readiness:
+          # Including liveness checks here as readiness is a superset of liveness
+          include: livenessState,diskAccess,readinessState,ping
     info:
       enabled: false
   # Disabling the disk space healthcheck as the service going unhealthy prevents batches from being deleted (which frees up space).

--- a/staging-service/src/main/resources/application.yaml
+++ b/staging-service/src/main/resources/application.yaml
@@ -45,7 +45,7 @@ management:
         enabled: true
       group:
         liveness:
-          include: livenessState,
+          include: livenessState
         readiness:
           # Including liveness checks here as readiness is a superset of liveness
           include: livenessState,diskAccess,readinessState,ping


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=919158