### PR TITLE
US982029: Updates to move to DropWizard 5, Jersey 3.1, Jetty 12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,67 +478,67 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-configuration</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-core</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-health</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jackson</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jersey</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jetty</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-lifecycle</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-logging</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-metrics</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-request-logging</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-servlets</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-util</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-validation</artifactId>
-                <version>4.0.10</version>
+                <version>5.0.0-alpha.4</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.logback</groupId>
@@ -572,7 +572,12 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-jetty11</artifactId>
+                <artifactId>metrics-jetty12</artifactId>
+                <version>4.2.28</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jetty12-ee10</artifactId>
                 <version>4.2.28</version>
             </dependency>
             <dependency>
@@ -643,7 +648,7 @@
             <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
-                <version>5.0.0</version>
+                <version>6.1.0</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.validation</groupId>
@@ -674,6 +679,11 @@
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-agent</artifactId>
                 <version>1.15.7</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-jpms</artifactId>
+                <version>5.15.0</version>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.argparse4j</groupId>
@@ -754,47 +764,42 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-http</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-io</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-security</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>11.0.24</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlets</artifactId>
-                <version>11.0.24</version>
+                <artifactId>jetty-session</artifactId>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
-                <version>11.0.24</version>
+                <version>12.0.14</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-servlet</artifactId>
+                <version>12.0.14</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.toolchain.setuid</groupId>
-                <artifactId>jetty-setuid-java</artifactId>
-                <version>1.0.4</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>4.0.2</version>
+                <artifactId>jetty-setuid-jna</artifactId>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.expressly</groupId>
@@ -829,57 +834,57 @@
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet-core</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-client</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-common</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-server</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-bean-validation</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-entity-filtering</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-metainf-services</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.inject</groupId>
                 <artifactId>jersey-hk2</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-json-jackson</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
                 <artifactId>jersey-media-multipart</artifactId>
-                <version>3.0.16</version>
+                <version>3.1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.js</groupId>

--- a/worker-batch-ingestion-container/pom.xml
+++ b/worker-batch-ingestion-container/pom.xml
@@ -83,6 +83,15 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
+        <!--
+            Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
+            This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and a
+            version of DropWizard that includes it is released.
+        -->
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/worker-batch-ingestion-container/pom.xml
+++ b/worker-batch-ingestion-container/pom.xml
@@ -83,12 +83,12 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
-        <!--
-            Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
-            This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and a
-            version of DropWizard that includes it is released.
-        -->
         <dependency>
+            <!--
+                Work around an issue whereby the jakarta.el-api jar is not being included in the Docker image.
+                This may be fixed by https://github.com/dropwizard/dropwizard/pull/9570 but we won't know for sure until it is merged and
+                a version of DropWizard that includes it is released.
+            -->
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
         </dependency>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=982029