### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.cafdataprocessing.services.staging</groupId>
     <artifactId>staging-service-aggregator</artifactId>
+    <name>staging-service-aggregator</name>
     <packaging>pom</packaging>
     <version>3.3.5-SNAPSHOT</version>
     <modules>

--- a/staging-service-acceptance-tests/pom.xml
+++ b/staging-service-acceptance-tests/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>staging-service-acceptance-tests</artifactId>
+    <name>staging-service-acceptance-tests</name>
 
     <dependencies>
         <dependency>

--- a/staging-service-container/pom.xml
+++ b/staging-service-container/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>staging-service-container</artifactId>
+    <name>staging-service-container</name>
 
     <properties>
         <maven.install.skip>true</maven.install.skip>

--- a/staging-service-contract/pom.xml
+++ b/staging-service-contract/pom.xml
@@ -27,5 +27,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>staging-service-contract</artifactId>
+    <name>staging-service-contract</name>
 
 </project>

--- a/staging-service-internal-client/pom.xml
+++ b/staging-service-internal-client/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>staging-service-internal-client</artifactId>
+    <name>staging-service-internal-client</name>
 
     <dependencies>
         <dependency>

--- a/staging-service-shared/pom.xml
+++ b/staging-service-shared/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>staging-service-shared</artifactId>
+    <name>staging-service-shared</name>
 
     <dependencies>
         <dependency>

--- a/staging-service/pom.xml
+++ b/staging-service/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>staging-service</artifactId>
+    <name>staging-service</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/worker-batch-ingestion-container-testing/pom.xml
+++ b/worker-batch-ingestion-container-testing/pom.xml
@@ -30,6 +30,7 @@
 
     <groupId>com.github.cafdataprocessing.workers.ingestion</groupId>
     <artifactId>worker-batch-ingestion-container-testing</artifactId>
+    <name>worker-batch-ingestion-container-testing</name>
 
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/worker-batch-ingestion-plugin/pom.xml
+++ b/worker-batch-ingestion-plugin/pom.xml
@@ -29,6 +29,7 @@
 
     <groupId>com.github.cafdataprocessing.workers.ingestion</groupId>
     <artifactId>worker-batch-ingestion-plugin</artifactId>
+    <name>worker-batch-ingestion-plugin</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210
