### PR TITLE
US1053037: Updated swagger-ui versions to support the latest change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <dependency>
                 <groupId>com.github.cafapi</groupId>
                 <artifactId>swagger-ui-annotation</artifactId>
-                <version>2.0.0-311</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.cafapi.common</groupId>
@@ -424,7 +424,7 @@
             <dependency>
                 <groupId>com.microfocus.webjars</groupId>
                 <artifactId>swagger-ui-dist</artifactId>
-                <version>2.0.0-191</version>
+                <version>2.1.0-356</version>
             </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>


### PR DESCRIPTION
Updated swagger-ui versions to ensure compatibility with latest change in the central caf-swagger service (https://github.com/CAFapi/caf-swagger)