### PR TITLE
US1041197: Reduced CAF_STAGING_SERVICE_DISK_SIZE_THRESHOLD default to 256MB

### DIFF
--- a/release-notes-3.3.9.md
+++ b/release-notes-3.3.9.md
@@ -4,6 +4,6 @@
 ${version-number}
 
 #### New Features
-- US1041197: Reduced CAF_STAGING_SERVICE_DISK_SIZE_THRESHOLD to 265MB 
+- US1041197: Reduced CAF_STAGING_SERVICE_DISK_SIZE_THRESHOLD to 256MB 
 
 #### Known Issues

--- a/release-notes-3.3.9.md
+++ b/release-notes-3.3.9.md
@@ -4,6 +4,6 @@
 ${version-number}
 
 #### New Features
-- US1041197: Reduced CAF_STAGING_SERVICE_DISK_SIZE_THRESHOLD to 256MB 
+- US1041197: Reduced CAF_STAGING_SERVICE_DISK_SIZE_THRESHOLD default to 256MB 
 
 #### Known Issues

--- a/release-notes-3.3.9.md
+++ b/release-notes-3.3.9.md
@@ -4,5 +4,6 @@
 ${version-number}
 
 #### New Features
+- US1041197: Reduced CAF_STAGING_SERVICE_DISK_SIZE_THRESHOLD to 265MB 
 
 #### Known Issues

--- a/staging-service/src/main/resources/application.yaml
+++ b/staging-service/src/main/resources/application.yaml
@@ -79,7 +79,7 @@ staging:
     skipFileCleanUp: ${CAF_STAGING_SERVICE_SKIP_FILE_CLEANUP:false}
     healthcheckTimeoutSeconds: ${CAF_STAGING_SERVICE_HEALTHCHECK_TIMEOUT_SECONDS:10}
     diskSpaceCheckPath: ${CAF_STAGING_SERVICE_BASEPATH:/batches/}
-    diskSpaceCheckThreshold: ${CAF_STAGING_SERVICE_DISK_SIZE_THRESHOLD:536870912}
+    diskSpaceCheckThreshold: ${CAF_STAGING_SERVICE_DISK_SIZE_THRESHOLD:268435456}
 logging:
   level:
     ROOT: ${CAF_LOG_LEVEL:WARN}


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1041197