### PR TITLE
US1054280: Update to json-schema-validator 2.0.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,17 +284,17 @@
             <dependency>
                 <groupId>com.github.cafdataprocessing.workers.document</groupId>
                 <artifactId>worker-document-schema</artifactId>
-                <version>7.1.0-1518</version>
+                <version>7.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.cafdataprocessing.workers.document</groupId>
                 <artifactId>worker-document-shared</artifactId>
-                <version>7.1.0-1518</version>
+                <version>7.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.cafdataprocessing.workers.document</groupId>
                 <artifactId>worker-document-validator</artifactId>
-                <version>7.1.0-1518</version>
+                <version>7.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.cafdataprocessing.workers.ingestion</groupId>
@@ -429,7 +429,7 @@
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
-                <version>1.5.9</version>
+                <version>2.0.0</version>
             </dependency>
             <dependency>
                 <groupId>com.rabbitmq</groupId>


### PR DESCRIPTION
Update to json-schema-validator 2.0.0 and compatibility upgrades for library projects
Issue link - [US1054280 - Update to json-schema-validator 2.0.0](https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1054280)